### PR TITLE
Update pay-respects to version 0.6.8

### DIFF
--- a/Formula/pay-respects.rb
+++ b/Formula/pay-respects.rb
@@ -1,14 +1,14 @@
 class PayRespects < Formula
   desc "CLI tool to pay respects"
   homepage "https://github.com/iffse/pay-respects"
-  version "0.6.7"
+  version "0.6.8"
 
   if Hardware::CPU.arm?
-    url "https://github.com/iffse/pay-respects/releases/download/v0.6.7/pay-respects-0.6.7-aarch64-apple-darwin.tar.zst"
-    sha256 "TO_BE_FILLED_IN_BY_GITHUB_ACTIONS"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.6.8/pay-respects-0.6.8-aarch64-apple-darwin.tar.zst"
+    sha256 "bc99d8cd66aa22afce7677a8247c249d2b4867489cdcd812c0b716cd39b63177"
   else
-    url "https://github.com/iffse/pay-respects/releases/download/v0.6.7/pay-respects-0.6.7-x86_64-apple-darwin.tar.zst"
-    sha256 "TO_BE_FILLED_IN_BY_GITHUB_ACTIONS"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.6.8/pay-respects-0.6.8-x86_64-apple-darwin.tar.zst"
+    sha256 "dbd110d19e39f3fa3de995d93a355ed5320c9766386bd42785a4a5010f2d9593"
   end
 
   def install
@@ -21,4 +21,4 @@ class PayRespects < Formula
   test do
     system "#{bin}/pay-respects", "--version"
   end
-end 
+end

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ brew install rexkyng/homebrew-tap/{formula}
 
 | Formula                                                 | Version | Description                                                                    |
 | ------------------------------------------------------- | ------- | ------------------------------------------------------------------------------ |
-| [`pay-respects`](https://codeberg.org/iff/pay-respects) | `0.6.7` | Command suggestions, command-not-found and thefuck replacement written in Rust |
+| [`pay-respects` | `0.6.8` | Command suggestions, command-not-found and thefuck replacement written in Rust |


### PR DESCRIPTION
Automated update of pay-respects to version 0.6.8

- Updated version to 0.6.8
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md