### PR TITLE
Update TheBoringNotch to version jellyfin.snoring

### DIFF
--- a/Casks/theboringnotch.rb
+++ b/Casks/theboringnotch.rb
@@ -1,5 +1,5 @@
 cask "theboringnotch" do
-  version "jolly.dolphin"
+  version "jellyfin.snoring"
   sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
 
   url "https://github.com/TheBoredTeam/boring.notch/releases/download/#{version}/#{version.split('-').map(&:capitalize).join}.dmg"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ brew install timescam/tap/{formula}
 | Formula          | Version         | Description                                                                                                               |
 | ---------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `pay-respects`   | `0.6.10`        | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects |
-| `TheBoringNotch` | `jolly.dolphin` | TheBoringNotch: Not so boring notch That Rocks 🎸🎶 <br />https://github.com/TheBoredTeam/boring.notch                    |
+| `TheBoringNotch` | `jellyfin.snoring` | TheBoringNotch: Not so boring notch That Rocks 🎸🎶 <br />https://github.com/TheBoredTeam/boring.notch                    |
 | `localsend-go`   | `1.2.0`         | CLI for localsend implemented in Go <br />https://github.com/meowrain/localsend-go                                        |
 
 ### Not tracked by daily GitHub Actions


### PR DESCRIPTION
Automated update of TheBoringNotch to version jellyfin.snoring

- Updated version to jellyfin.snoring
- Updated SHA256 checksum
- Updated version in README.md