### PR TITLE
Update pokeget to version null

### DIFF
--- a/Formula/pokeget.rb
+++ b/Formula/pokeget.rb
@@ -1,16 +1,16 @@
 class Pokeget < Formula
   desc "A command line utility to display pokemon sprites in the terminal"
   homepage "https://github.com/talwat/pokeget-rs"
-  version "1.6.3"
+  version "null"
 
   on_arm do
     url "https://github.com/talwat/pokeget-rs/releases/download/#{version}/pokeget-macOS-aarch64.tar.gz"
-    sha256 "db0db6139d6a2ab208e4080537caf5f0661a94eaef38ffe1a1d93ddb1dd625c1"
+    sha256 "Not"
   end
 
   on_intel do
     url "https://github.com/talwat/pokeget-rs/releases/download/#{version}/pokeget-macOS-x86_64.tar.gz"
-    sha256 "f2157996dd15270a3a2a9c35212bda31c48017ad2625c643e207c3c6942dac60"
+    sha256 "Not"
   end
 
   def install

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ brew install timescam/tap/{formula}
 | `TheBoringNotch` | `jellyfin.snoring` | TheBoringNotch: Not so boring notch That Rocks 🎸🎶 <br />https://github.com/TheBoredTeam/boring.notch                    |
 | `localsend-go`   | `1.2.0`            | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                         |
 | `imFile`         | `1.1.2`            | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                        |
-| `pokeget`        | `1.6.3`            | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                               |
+| `pokeget` | `null` | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                               |
 
 ### Not tracked by daily GitHub Actions
 


### PR DESCRIPTION
Automated update of pokeget to version null

- Updated version to null
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md