### PR TITLE
Update localsend-go to version 1.2.1

### DIFF
--- a/Formula/localsend-go.rb
+++ b/Formula/localsend-go.rb
@@ -1,7 +1,7 @@
 class LocalsendGo < Formula
   desc "CLI for localsend implemented in Go"
   homepage "https://github.com/meowrain/localsend-go"
-  version "1.2.0"
+  version "1.2.1"
 
   on_arm do
     url "https://github.com/meowrain/localsend-go/releases/download/v#{version}/localsend_cli-darwin-arm64"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ brew install timescam/tap/{formula}
 | ---------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------- |
 | `pay-respects` | `0.6.12` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects |
 | `TheBoringNotch` | `jellyfin.snoring` | TheBoringNotch: Not so boring notch That Rocks 🎸🎶 <br />https://github.com/TheBoredTeam/boring.notch                    |
-| `localsend-go`   | `1.2.0`            | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                         |
+| `localsend-go` | `1.2.1` | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                         |
 | `imFile`         | `1.1.2`            | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                        |
 | `pokeget` | `null` | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                               |
 


### PR DESCRIPTION
Automated update of localsend-go to version 1.2.1

- Updated version to 1.2.1
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md