### PR TITLE
Update localsend-go to version 1.2.2

### DIFF
--- a/Formula/localsend-go.rb
+++ b/Formula/localsend-go.rb
@@ -1,16 +1,16 @@
 class LocalsendGo < Formula
   desc "CLI for localsend implemented in Go"
   homepage "https://github.com/meowrain/localsend-go"
-  version "null"
+  version "1.2.2"
 
   on_arm do
     url "https://github.com/meowrain/localsend-go/releases/download/v#{version}/localsend_cli-darwin-arm64"
-    sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+    sha256 "bb4cd615e7b8ab72858a264544919f2231b45c9fb5a09fdb9c8ec45f39e56132"
   end
 
   on_intel do
     url "https://github.com/meowrain/localsend-go/releases/download/v#{version}/localsend_cli-darwin-amd64"
-    sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+    sha256 "d07c12de7268cde60bf13e9ad5346ba0611ed881a260ce48aeccb52d2dcd9fc8"
   end
 
   def install


### PR DESCRIPTION
Automated update of localsend-go to version 1.2.2

- Updated version to 1.2.2
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md