### PR TITLE
Update localsend-go to version 1.2.5

### DIFF
--- a/Formula/localsend-go.rb
+++ b/Formula/localsend-go.rb
@@ -1,16 +1,16 @@
 class LocalsendGo < Formula
   desc "CLI for localsend implemented in Go"
   homepage "https://github.com/meowrain/localsend-go"
-  version "1.2.4"
+  version "1.2.5"
 
   on_arm do
     url "https://github.com/meowrain/localsend-go/releases/download/v#{version}/localsend_cli-darwin-arm64"
-    sha256 "afb88e3bb4e10c657fb9cee12f5430d9925cd08a8533144a35ce5da5fde4ecca"
+    sha256 "b30cca0c78660c1cb6f87dfb0e913803b1f77b157b1bba1fa8a83000cae1ca41"
   end
 
   on_intel do
     url "https://github.com/meowrain/localsend-go/releases/download/v#{version}/localsend_cli-darwin-amd64"
-    sha256 "e552a3d6ec1f271fef64219b58dbe0c06558b84769b07605864130d3aed587f3"
+    sha256 "28f2b34d832fd55d71fabde19604b7c2c437db7181c8642fd40373b6b8b9a7b5"
   end
 
   def install

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ brew install timescam/tap/{formula}
 | ---------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------- |
 | `pay-respects`   | `0.6.13`           | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects |
 | `TheBoringNotch` | `wolf.painting` | TheBoringNotch: Not so boring notch That Rocks 🎸🎶 <br />https://github.com/TheBoredTeam/boring.notch                    |
-| `localsend-go` | `1.2.4` | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                         |
+| `localsend-go` | `1.2.5` | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                         |
 | `imFile`         | `1.1.2`            | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                        |
 | `pokeget`        | `1.6.3`            | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                               |
 


### PR DESCRIPTION
Automated update of localsend-go to version 1.2.5

- Updated version to 1.2.5
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md