### PR TITLE
Update pay-respects to version 0.6.14

### DIFF
--- a/Formula/pay-respects.rb
+++ b/Formula/pay-respects.rb
@@ -1,7 +1,7 @@
 class PayRespects < Formula
   desc "CLI tool to pay respects"
   homepage "https://github.com/iffse/pay-respects"
-  version "0.6.13"
+  version "0.6.14"
 
   on_arm do
     url "https://github.com/iffse/pay-respects/releases/download/v0.6.10/pay-respects-0.6.10-aarch64-apple-darwin.tar.zst"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ brew install timescam/tap/{formula}
 
 | Formula          | Version            | Description                                                                                                               |
 | ---------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| `pay-respects`   | `0.6.13`           | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects |
+| `pay-respects` | `0.6.14` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects |
 | `TheBoringNotch` | `wolf.painting` | TheBoringNotch: Not so boring notch That Rocks 🎸🎶 <br />https://github.com/TheBoredTeam/boring.notch                    |
 | `localsend-go` | `1.2.5` | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                         |
 | `imFile`         | `1.1.2`            | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                        |


### PR DESCRIPTION
Automated update of pay-respects to version 0.6.14

- Updated version to 0.6.14
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md