### PR TITLE
Update pokeget to version 1.6.3

### DIFF
--- a/Formula/pokeget.rb
+++ b/Formula/pokeget.rb
@@ -1,16 +1,16 @@
 class Pokeget < Formula
   desc "A command line utility to display pokemon sprites in the terminal"
   homepage "https://github.com/talwat/pokeget-rs"
-  version "null"
+  version "1.6.3"
 
   on_arm do
     url "https://github.com/talwat/pokeget-rs/releases/download/#{version}/pokeget-macOS-aarch64.tar.gz"
-    sha256 "Not"
+    sha256 "db0db6139d6a2ab208e4080537caf5f0661a94eaef38ffe1a1d93ddb1dd625c1"
   end
 
   on_intel do
     url "https://github.com/talwat/pokeget-rs/releases/download/#{version}/pokeget-macOS-x86_64.tar.gz"
-    sha256 "Not"
+    sha256 "f2157996dd15270a3a2a9c35212bda31c48017ad2625c643e207c3c6942dac60"
   end
 
   def install


### PR DESCRIPTION
Automated update of pokeget to version 1.6.3

- Updated version to 1.6.3
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md