### PR TITLE
Update localsend-go to version null

### DIFF
--- a/Formula/localsend-go.rb
+++ b/Formula/localsend-go.rb
@@ -1,16 +1,16 @@
 class LocalsendGo < Formula
   desc "CLI for localsend implemented in Go"
   homepage "https://github.com/meowrain/localsend-go"
-  version "1.2.5"
+  version "null"
 
   on_arm do
     url "https://github.com/meowrain/localsend-go/releases/download/v#{version}/localsend_cli-darwin-arm64"
-    sha256 "b30cca0c78660c1cb6f87dfb0e913803b1f77b157b1bba1fa8a83000cae1ca41"
+    sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
   end
 
   on_intel do
     url "https://github.com/meowrain/localsend-go/releases/download/v#{version}/localsend_cli-darwin-amd64"
-    sha256 "28f2b34d832fd55d71fabde19604b7c2c437db7181c8642fd40373b6b8b9a7b5"
+    sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
   end
 
   def install

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ brew install timescam/tap/{formula}
 | ---------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------- |
 | `pay-respects` | `0.6.14` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects |
 | `TheBoringNotch` | `wolf.painting` | TheBoringNotch: Not so boring notch That Rocks 🎸🎶 <br />https://github.com/TheBoredTeam/boring.notch                    |
-| `localsend-go` | `1.2.5` | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                         |
+| `localsend-go` | `null` | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                         |
 | `imFile`         | `1.1.2`            | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                        |
 | `pokeget` | `null` | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                               |
 


### PR DESCRIPTION
Automated update of localsend-go to version null

- Updated version to null
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md