### PR TITLE
Update pay-respects to version 0.7.5

### DIFF
--- a/Formula/pay-respects.rb
+++ b/Formula/pay-respects.rb
@@ -1,16 +1,16 @@
 class PayRespects < Formula
   desc "CLI tool to pay respects"
   homepage "https://github.com/iffse/pay-respects"
-  version "0.7.3"
+  version "0.7.5"
 
   on_arm do
-    url "https://github.com/iffse/pay-respects/releases/download/v0.7.3/pay-respects-0.7.3-aarch64-apple-darwin.tar.zst"
-    sha256 "efadb82414c29e58af9d846eed295ccaec3365582ae37f8e2a6fbb937ae1d549"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.7.5/pay-respects-0.7.5-aarch64-apple-darwin.tar.zst"
+    sha256 "297b970d67b05bee4b1b451727cd348b89ccc4a16575e73f3014dfcc578220cb"
   end
 
   on_intel do
-    url "https://github.com/iffse/pay-respects/releases/download/v0.7.3/pay-respects-0.7.3-x86_64-apple-darwin.tar.zst"
-    sha256 "59af7cd4d9208ee21bb4e79ae4a3a23ed86e729fd54268d1255699157ee8712b"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.7.5/pay-respects-0.7.5-x86_64-apple-darwin.tar.zst"
+    sha256 "e808fc2df9b1813f968d6d54621296f374f755d4ba9a85357d41523e39b5c546"
   end
 
   def install

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ brew install timescam/tap/{formula}
 
 | Formula          | Version         | Description                                                                                                               |
 | ---------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `pay-respects` | `0.7.3` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects |
+| `pay-respects` | `0.7.5` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects |
 | `TheBoringNotch` | `wolf.painting` | TheBoringNotch: Not so boring notch That Rocks 🎸🎶 <br />https://github.com/TheBoredTeam/boring.notch                    |
 | `localsend-go` | `1.2.7` | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                         |
 | `imFile`         | `1.1.2`         | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                        |


### PR DESCRIPTION
Automated update of pay-respects to version 0.7.5

- Updated version to 0.7.5
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md