### PR TITLE
Update pay-respects to version 0.7.8

### DIFF
--- a/Formula/pay-respects.rb
+++ b/Formula/pay-respects.rb
@@ -1,16 +1,16 @@
 class PayRespects < Formula
   desc "CLI tool to pay respects"
   homepage "https://github.com/iffse/pay-respects"
-  version "0.7.6"
+  version "0.7.8"
 
   on_arm do
-    url "https://github.com/iffse/pay-respects/releases/download/v0.7.6/pay-respects-0.7.6-aarch64-apple-darwin.tar.zst"
-    sha256 "08fd0f83aa9bc4891710a8b0914d964c4be78c38e124300897891941ebc83de6"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.7.8/pay-respects-0.7.8-aarch64-apple-darwin.tar.zst"
+    sha256 "3d17d08b9a3a1f045952ea9d6034c8519786775db2a8c3b948a5657878aab239"
   end
 
   on_intel do
-    url "https://github.com/iffse/pay-respects/releases/download/v0.7.6/pay-respects-0.7.6-x86_64-apple-darwin.tar.zst"
-    sha256 "5d446d8338da3ccf33da0ac2ab57d0628adb080acdc0b8644840e63cdfeb41ee"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.7.8/pay-respects-0.7.8-x86_64-apple-darwin.tar.zst"
+    sha256 "179dcf08610de9e4d18bad6dc930886b6fe01371108c25a02a273ce6f11aa312"
   end
 
   def install

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ brew install timescam/tap/{formula}
 
 | Formula          | Version         | Description                                                                                                                    |
 | ---------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `pay-respects`   | `0.7.6`         | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects      |
+| `pay-respects` | `0.7.8` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects      |
 | `TheBoringNotch` | `wolf.painting` | TheBoringNotch: Not so boring notch That Rocks 🎸🎶 <br />https://github.com/TheBoredTeam/boring.notch                         |
 | `localsend-go`   | `1.2.7`         | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                              |
 | `imFile`         | `1.1.2`         | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                             |


### PR DESCRIPTION
Automated update of pay-respects to version 0.7.8

- Updated version to 0.7.8
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md