### PR TITLE
Update gopeed-web to version 1.7.1

### DIFF
--- a/Formula/gopeed-web.rb
+++ b/Formula/gopeed-web.rb
@@ -1,16 +1,16 @@
 class GopeedWeb < Formula
   desc "A modern download manager that supports all platforms. Built with Golang and Flutter."
   homepage "https://github.com/GopeedLab/gopeed"
-  version "1.7.0"
+  version "1.7.1"
   
   on_arm do
-    url "https://github.com/GopeedLab/gopeed/releases/download/v1.7.0/gopeed-web-v1.7.0-macos-arm64.zip"
-    sha256 "834f12788a764656cc35e3119c5c48bc2312a2d6d850952ccfc808e3b1193f61"
+    url "https://github.com/GopeedLab/gopeed/releases/download/v1.7.1/gopeed-web-v1.7.1-macos-arm64.zip"
+    sha256 "98199a96d8dfaf5299a9c060e0dca350e61491378e290de85c5be8a8f176b80d"
   end
   
   on_intel do
-    url "https://github.com/GopeedLab/gopeed/releases/download/v1.7.0/gopeed-web-v1.7.0-macos-amd64.zip"
-    sha256 "06306de3920661c72c7c7f5b838b516af56105bd2eaf5d8650453408935d3bbb"
+    url "https://github.com/GopeedLab/gopeed/releases/download/v1.7.1/gopeed-web-v1.7.1-macos-amd64.zip"
+    sha256 "ac82adb54dcaf1458938b70f2c9f4b291a904b934da4bda4561a3631f5441fbe"
   end
   
   def install

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ brew install timescam/tap/{formula}
 | `localsend-go`   | `1.2.7`         | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                              |
 | `imFile`         | `1.1.2`         | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                             |
 | `pokeget` | `1.6.5` | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                    |
-| `gopeed-web`     | `1.7.0`         | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed |
+| `gopeed-web` | `1.7.1` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed |
 
 ### Not tracked by daily GitHub Actions
 


### PR DESCRIPTION
Automated update of gopeed-web to version 1.7.1

- Updated version to 1.7.1
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md