### PR TITLE
Update TheBoringNotch to version v2.7-rc.1

### DIFF
--- a/Casks/theboringnotch.rb
+++ b/Casks/theboringnotch.rb
@@ -1,5 +1,5 @@
 cask "theboringnotch" do
-  version "v2.7-rc.0"
+  version "v2.7-rc.1"
   sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
 
   url "https://github.com/TheBoredTeam/boring.notch/releases/download/#{version}/#{version.split('.').map(&:capitalize).join}.dmg"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ brew install timescam/tap/{formula}
 | Formula          | Version         | Description                                                                                                                    |
 | ---------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `pay-respects` | `0.7.8` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects      |
-| `TheBoringNotch` | `v2.7-rc.0` | TheBoringNotch: Not so boring notch That Rocks 🎸🎶 <br />https://github.com/TheBoredTeam/boring.notch                         |
+| `TheBoringNotch` | `v2.7-rc.1` | TheBoringNotch: Not so boring notch That Rocks 🎸🎶 <br />https://github.com/TheBoredTeam/boring.notch                         |
 | `localsend-go`   | `1.2.7`         | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                              |
 | `imFile`         | `1.1.2`         | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                             |
 | `pokeget` | `1.6.5` | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                    |


### PR DESCRIPTION
Automated update of TheBoringNotch to version v2.7-rc.1

- Updated version to v2.7-rc.1
- Updated SHA256 checksum
- Updated version in README.md