### PR TITLE
Update TheBoringNotch to version v2.7-rc.1

### DIFF
--- a/Casks/theboringnotch.rb
+++ b/Casks/theboringnotch.rb
@@ -1,8 +1,8 @@
 cask "theboringnotch" do
-  version "wolf.painting"
-  sha256 "1a58ec27e5de30faf107fdf8b77575b1c39ace69e77b1330fc4ed6562bf2badc"
+  version "v2.7-rc.1"
+  sha256 "a4751822b2c72e3a5c3d41a3307421557f7f0717cf66e9f66faf3ce0e4d4103e"
 
-  url "https://github.com/TheBoredTeam/boring.notch/releases/download/#{version}/#{version.split('.').map(&:capitalize).join}.dmg"
+  url "https://github.com/TheBoredTeam/boring.notch/releases/download/v2.7-rc.1/Flying_Rabbit.dmg"
   name "TheBoringNotch"
   desc "Not so boring notch That Rocks 🎸🎶"
   homepage "https://github.com/TheBoredTeam/boring.notch"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ brew install timescam/tap/{formula}
 | Formula          | Version         | Description                                                                                                                    |
 | ---------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `pay-respects` | `0.7.8` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects      |
-| `TheBoringNotch` | `wolf.painting` | TheBoringNotch: Not so boring notch That Rocks 🎸🎶 <br />https://github.com/TheBoredTeam/boring.notch                         |
+| `TheBoringNotch` | `v2.7-rc.1` | TheBoringNotch: Not so boring notch That Rocks 🎸🎶 <br />https://github.com/TheBoredTeam/boring.notch                         |
 | `localsend-go`   | `1.2.7`         | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                              |
 | `imFile`         | `1.1.2`         | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                             |
 | `pokeget` | `1.6.5` | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                    |


### PR DESCRIPTION
Automated update of TheBoringNotch to version v2.7-rc.1

- Updated version to v2.7-rc.1
- Updated SHA256 checksum
- Updated download URL to https://github.com/TheBoredTeam/boring.notch/releases/download/v2.7-rc.1/Flying_Rabbit.dmg
- Updated version in README.md