### PR TITLE
Update gopeed-web to version 1.8.0

### DIFF
--- a/Formula/gopeed-web.rb
+++ b/Formula/gopeed-web.rb
@@ -1,16 +1,16 @@
 class GopeedWeb < Formula
   desc "A modern download manager that supports all platforms. Built with Golang and Flutter."
   homepage "https://github.com/GopeedLab/gopeed"
-  version "1.7.1"
+  version "1.8.0"
   
   on_arm do
-    url "https://github.com/GopeedLab/gopeed/releases/download/v1.7.1/gopeed-web-v1.7.1-macos-arm64.zip"
-    sha256 "98199a96d8dfaf5299a9c060e0dca350e61491378e290de85c5be8a8f176b80d"
+    url "https://github.com/GopeedLab/gopeed/releases/download/v1.8.0/gopeed-web-v1.8.0-macos-arm64.zip"
+    sha256 "fab217a326cbfac9639150d8c7ab3e8f88326f5fd838630f716ee7ab7944393f"
   end
   
   on_intel do
-    url "https://github.com/GopeedLab/gopeed/releases/download/v1.7.1/gopeed-web-v1.7.1-macos-amd64.zip"
-    sha256 "ac82adb54dcaf1458938b70f2c9f4b291a904b934da4bda4561a3631f5441fbe"
+    url "https://github.com/GopeedLab/gopeed/releases/download/v1.8.0/gopeed-web-v1.8.0-macos-amd64.zip"
+    sha256 "32f0461a3418443db3832910cf0370230a315b398a866574bbef68413f1305c0"
   end
   
   def install

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ brew install timescam/tap/{formula}
 | `localsend-go` | `1.2.7` | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                              |
 | `imFile`       | `1.1.2` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                             |
 | `pokeget`      | `1.6.5` | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                    |
-| `gopeed-web`   | `1.7.1` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed |
+| `gopeed-web` | `1.8.0` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed |
 
 ### Not tracked by daily GitHub Actions
 


### PR DESCRIPTION
Automated update of gopeed-web to version 1.8.0

- Updated version to 1.8.0
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated download URLs to https://github.com/GopeedLab/gopeed/releases/download/v1.8.0/gopeed-web-v1.8.0-macos-arm64.zip and https://github.com/GopeedLab/gopeed/releases/download/v1.8.0/gopeed-web-v1.8.0-macos-amd64.zip
- Updated version in README.md