### PR TITLE
Update gopeed-web to version 1.8.1

### DIFF
--- a/Formula/gopeed-web.rb
+++ b/Formula/gopeed-web.rb
@@ -1,16 +1,16 @@
 class GopeedWeb < Formula
   desc "A modern download manager that supports all platforms. Built with Golang and Flutter."
   homepage "https://github.com/GopeedLab/gopeed"
-  version "1.8.0"
+  version "1.8.1"
   
   on_arm do
-    url "https://github.com/GopeedLab/gopeed/releases/download/v1.8.0/gopeed-web-v1.8.0-macos-arm64.zip"
-    sha256 "e3c5bb23a572cef45bfcffa7ce33a923cf2524a8d9b137ddac2842a7d599120b"
+    url "https://github.com/GopeedLab/gopeed/releases/download/v1.8.1/gopeed-web-v1.8.1-macos-arm64.zip"
+    sha256 "c79269a85dccc8363e257dcade0a4c8830dfc966c858bc7cc2026b14b1caa2f2"
   end
   
   on_intel do
-    url "https://github.com/GopeedLab/gopeed/releases/download/v1.8.0/gopeed-web-v1.8.0-macos-amd64.zip"
-    sha256 "d44a3d8f75f7a156b61fda30ac4f68c75e700a30e3902a00078c05c27d7684ba"
+    url "https://github.com/GopeedLab/gopeed/releases/download/v1.8.1/gopeed-web-v1.8.1-macos-amd64.zip"
+    sha256 "a7d403c31563a125f54bc5e6f4d8e2de6b1cea82ce506ad624cf96df19df1a41"
   end
   
   def install

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ brew install timescam/tap/{formula}
 | `localsend-go` | `1.2.7` | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                              |
 | `imFile`       | `1.1.2` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                             |
 | `pokeget`      | `1.6.5` | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                    |
-| `gopeed-web` | `1.8.0` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed |
+| `gopeed-web` | `1.8.1` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed |
 
 ### Not tracked by daily GitHub Actions
 


### PR DESCRIPTION
Automated update of gopeed-web to version 1.8.1

- Updated version to 1.8.1
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated download URLs to https://github.com/GopeedLab/gopeed/releases/download/v1.8.1/gopeed-web-v1.8.1-macos-arm64.zip and https://github.com/GopeedLab/gopeed/releases/download/v1.8.1/gopeed-web-v1.8.1-macos-amd64.zip
- Updated version in README.md