### PR TITLE
Update gopeed-web to version 1.8.2

### DIFF
--- a/Formula/gopeed-web.rb
+++ b/Formula/gopeed-web.rb
@@ -1,16 +1,16 @@
 class GopeedWeb < Formula
   desc "A modern download manager that supports all platforms. Built with Golang and Flutter."
   homepage "https://github.com/GopeedLab/gopeed"
-  version "1.8.1"
+  version "1.8.2"
   
   on_arm do
-    url "https://github.com/GopeedLab/gopeed/releases/download/v1.8.1/gopeed-web-v1.8.1-macos-arm64.zip"
-    sha256 "c79269a85dccc8363e257dcade0a4c8830dfc966c858bc7cc2026b14b1caa2f2"
+    url "https://github.com/GopeedLab/gopeed/releases/download/v1.8.2/gopeed-web-v1.8.2-macos-arm64.zip"
+    sha256 "32fb76c260bfbd5782a265b645a2830cd0647e3b172ac83895796a04e362dae6"
   end
   
   on_intel do
-    url "https://github.com/GopeedLab/gopeed/releases/download/v1.8.1/gopeed-web-v1.8.1-macos-amd64.zip"
-    sha256 "a7d403c31563a125f54bc5e6f4d8e2de6b1cea82ce506ad624cf96df19df1a41"
+    url "https://github.com/GopeedLab/gopeed/releases/download/v1.8.2/gopeed-web-v1.8.2-macos-amd64.zip"
+    sha256 "254d0752fd8b134f01c3c5c698f32a63249c110065b2009bce123b8221c3bab0"
   end
   
   def install

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ brew install timescam/tap/{formula}
 | `localsend-go` | `1.2.7` | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                              |
 | `imFile`       | `1.1.2` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                             |
 | `pokeget`      | `1.6.5` | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                    |
-| `gopeed-web` | `1.8.1` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed |
+| `gopeed-web` | `1.8.2` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed |
 
 ### Not tracked by daily GitHub Actions
 


### PR DESCRIPTION
Automated update of gopeed-web to version 1.8.2

- Updated version to 1.8.2
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated download URLs to https://github.com/GopeedLab/gopeed/releases/download/v1.8.2/gopeed-web-v1.8.2-macos-arm64.zip and https://github.com/GopeedLab/gopeed/releases/download/v1.8.2/gopeed-web-v1.8.2-macos-amd64.zip
- Updated version in README.md