### PR TITLE
Update pokeget to version 1.6.7

### DIFF
--- a/Formula/pokeget.rb
+++ b/Formula/pokeget.rb
@@ -1,16 +1,16 @@
 class Pokeget < Formula
   desc "A command line utility to display pokemon sprites in the terminal"
   homepage "https://github.com/talwat/pokeget-rs"
-  version "1.6.5"
+  version "1.6.7"
 
   on_arm do
     url "https://github.com/talwat/pokeget-rs/releases/download/#{version}/pokeget-macOS-aarch64.tar.gz"
-    sha256 "2e524bde1df6f73f3130add15f25d3bcf67083a2f2609b3d8b686ef9be65fa5d"
+    sha256 "0bf716d188e1d226778568ddd6d9f832a124db4490f0da256d53788634f2e544"
   end
 
   on_intel do
     url "https://github.com/talwat/pokeget-rs/releases/download/#{version}/pokeget-macOS-x86_64.tar.gz"
-    sha256 "ae2b903ec4e452f1eea953646bfe4aee2e05d6078150f2a292d58bb40b075feb"
+    sha256 "f5813f93d131c9d04bc4326dc35198e63fe9b631d024c883d140d00920ddd9d7"
   end
 
   def install

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ brew install timescam/tap/{formula}
 | `pay-respects` | `0.7.9` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects      |
 | `localsend-go` | `1.2.7` | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                              |
 | `imFile`       | `1.1.2` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                             |
-| `pokeget`      | `1.6.5` | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                    |
+| `pokeget` | `1.6.7` | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                    |
 | `gopeed-web`   | `1.8.2` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed |
 
 ### Not tracked by daily GitHub Actions


### PR DESCRIPTION
Automated update of pokeget to version 1.6.7

- Updated version to 1.6.7
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md