### PR TITLE
Update gopeed-web to version 1.8.3

### DIFF
--- a/Formula/gopeed-web.rb
+++ b/Formula/gopeed-web.rb
@@ -1,16 +1,16 @@
 class GopeedWeb < Formula
   desc "A modern download manager that supports all platforms. Built with Golang and Flutter."
   homepage "https://github.com/GopeedLab/gopeed"
-  version "1.8.2"
+  version "1.8.3"
   
   on_arm do
-    url "https://github.com/GopeedLab/gopeed/releases/download/v1.8.2/gopeed-web-v1.8.2-macos-arm64.zip"
-    sha256 "32fb76c260bfbd5782a265b645a2830cd0647e3b172ac83895796a04e362dae6"
+    url "https://github.com/GopeedLab/gopeed/releases/download/v1.8.3/gopeed-web-v1.8.3-macos-arm64.zip"
+    sha256 "9904787bb90461b8576342f71e2b5cf3840917c23e46856fa26f3bad23b2f699"
   end
   
   on_intel do
-    url "https://github.com/GopeedLab/gopeed/releases/download/v1.8.2/gopeed-web-v1.8.2-macos-amd64.zip"
-    sha256 "254d0752fd8b134f01c3c5c698f32a63249c110065b2009bce123b8221c3bab0"
+    url "https://github.com/GopeedLab/gopeed/releases/download/v1.8.3/gopeed-web-v1.8.3-macos-amd64.zip"
+    sha256 "1a2b42fbcdf2bca6374ccd1e73c2414a94dcc6299b9f74a75ece6063f5e7b57b"
   end
   
   def install

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ brew install timescam/tap/{formula}
 | `localsend-go` | `1.2.7` | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                              |
 | `imFile`       | `1.1.2` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                             |
 | `pokeget` | `1.6.7` | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                    |
-| `gopeed-web`   | `1.8.2` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed |
+| `gopeed-web` | `1.8.3` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed |
 
 ### Not tracked by daily GitHub Actions
 


### PR DESCRIPTION
Automated update of gopeed-web to version 1.8.3

- Updated version to 1.8.3
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated download URLs to https://github.com/GopeedLab/gopeed/releases/download/v1.8.3/gopeed-web-v1.8.3-macos-arm64.zip and https://github.com/GopeedLab/gopeed/releases/download/v1.8.3/gopeed-web-v1.8.3-macos-amd64.zip
- Updated version in README.md