### PR TITLE
Update gopeed-web to version 1.9.0

### DIFF
--- a/Formula/gopeed-web.rb
+++ b/Formula/gopeed-web.rb
@@ -1,16 +1,16 @@
 class GopeedWeb < Formula
   desc "A modern download manager that supports all platforms. Built with Golang and Flutter."
   homepage "https://github.com/GopeedLab/gopeed"
-  version "1.8.3"
+  version "1.9.0"
   
   on_arm do
-    url "https://github.com/GopeedLab/gopeed/releases/download/v1.8.3/gopeed-web-v1.8.3-macos-arm64.zip"
-    sha256 "9904787bb90461b8576342f71e2b5cf3840917c23e46856fa26f3bad23b2f699"
+    url "https://github.com/GopeedLab/gopeed/releases/download/v1.9.0/gopeed-web-v1.9.0-macos-arm64.zip"
+    sha256 "2d6940b3ad2a25f7e8bcdf274794cc2ba1b3576e5d0494dc7479cb891f5ec65b"
   end
   
   on_intel do
-    url "https://github.com/GopeedLab/gopeed/releases/download/v1.8.3/gopeed-web-v1.8.3-macos-amd64.zip"
-    sha256 "1a2b42fbcdf2bca6374ccd1e73c2414a94dcc6299b9f74a75ece6063f5e7b57b"
+    url "https://github.com/GopeedLab/gopeed/releases/download/v1.9.0/gopeed-web-v1.9.0-macos-amd64.zip"
+    sha256 "b47c7611df92f84b5292cdb11fafe3acef299a007412319686b49a56c891e870"
   end
   
   def install

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ brew install timescam/tap/{formula}
 | `localsend-go` | `1.2.7` | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                              |
 | `imFile`       | `1.1.2` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                             |
 | `pokeget` | `1.6.7` | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                    |
-| `gopeed-web` | `1.8.3` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed |
+| `gopeed-web` | `1.9.0` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed |
 
 ### Not tracked by daily GitHub Actions
 


### PR DESCRIPTION
Automated update of gopeed-web to version 1.9.0

- Updated version to 1.9.0
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated download URLs to https://github.com/GopeedLab/gopeed/releases/download/v1.9.0/gopeed-web-v1.9.0-macos-arm64.zip and https://github.com/GopeedLab/gopeed/releases/download/v1.9.0/gopeed-web-v1.9.0-macos-amd64.zip
- Updated version in README.md