### PR TITLE
Update localsend-go to version 1.2.7

### DIFF
--- a/Formula/localsend-go.rb
+++ b/Formula/localsend-go.rb
@@ -4,12 +4,12 @@ class LocalsendGo < Formula
   version "1.2.7"
 
   on_arm do
-    url "https://github.com/meowrain/localsend-go/releases/download/v#{version}/localsend-go-darwin-arm64"
+    url "https://github.com/meowrain/localsend-go/releases/download/v1.2.7/localsend-go-darwin-arm64"
     sha256 "2ee70ddde3e93a0401f36290a7294f6988595df2bb69edbd59d25ef6d2b623b9"
   end
 
   on_intel do
-    url "https://github.com/meowrain/localsend-go/releases/download/v#{version}/localsend-go-darwin-amd64"
+    url "https://github.com/meowrain/localsend-go/releases/download/v1.2.7/localsend-go-darwin-amd64"
     sha256 "0f796161068a558f74d71a599e76d8e98f6f95ca83a327fffb2ea0a5a0d2844a"
   end
 


### PR DESCRIPTION
Automated update of localsend-go to version 1.2.7

- Updated version to 1.2.7
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated download URLs to https://github.com/meowrain/localsend-go/releases/download/v1.2.7/localsend-go-darwin-arm64 and https://github.com/meowrain/localsend-go/releases/download/v1.2.7/localsend-go-darwin-amd64
- Updated version in README.md