### PR TITLE
Update imFile to version 1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ brew install timescam/tap/{formula}
 | -------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `pay-respects` | `0.7.9`  | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
 | `localsend-go` | `1.2.7` | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
-| `imFile`       | `1.1.2`  | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
+| `imFile` | `1.1.2` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
 | `pokeget`      | `1.6.7`  | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |
 | `zagi`         | `0.1.7`  | A better git for z.<br />https://github.com/mattzcarey/zagi                                                                                       |
 | `gopeed-web`   | `1.9.0`  | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed                    |


### PR DESCRIPTION
Automated update of imFile to version 1.1.2

- Updated version to 1.1.2
- Updated SHA256 checksums for both ARM and Intel builds
- Updated download URLs to https://github.com/imfile-io/imfile-desktop/releases/download/v1.1.2/imFile-1.1.2-arm64.dmg and https://github.com/imfile-io/imfile-desktop/releases/download/v1.1.2/imFile-1.1.2.dmg
- Updated version in README.md