### PR TITLE
Update zagi to version 0.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ brew install timescam/tap/{formula}
 | `localsend-go` | `1.2.7` | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
 | `imFile` | `1.1.2` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
 | `pokeget`      | `1.6.7`  | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |
-| `zagi`         | `0.1.7`  | A better git for z.<br />https://github.com/mattzcarey/zagi                                                                                       |
+| `zagi` | `0.1.7` | A better git for z.<br />https://github.com/mattzcarey/zagi                                                                                       |
 | `gopeed-web`   | `1.9.0`  | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed                    |
 | `spotatui`     | `0.35.5` | A fully standalone Spotify client for the terminal. Native streaming included, no daemon required.<br />https://github.com/LargeModGames/spotatui |
 


### PR DESCRIPTION
Automated update of zagi to version 0.1.7

- Updated version to 0.1.7
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md