### PR TITLE
Update pay-respects to version 0.7.11

### DIFF
--- a/Formula/pay-respects.rb
+++ b/Formula/pay-respects.rb
@@ -1,16 +1,16 @@
 class PayRespects < Formula
   desc "CLI tool to pay respects"
   homepage "https://github.com/iffse/pay-respects"
-  version "0.7.10"
+  version "0.7.11"
 
   on_arm do
-    url "https://github.com/iffse/pay-respects/releases/download/v0.7.10/pay-respects-0.7.10-aarch64-apple-darwin.tar.zst"
-    sha256 "7f6cafd66371f44e77f321e6543ad4ce8b4ffedb20282e2778ada512e7e0c825"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.7.11/pay-respects-0.7.11-aarch64-apple-darwin.tar.zst"
+    sha256 "297bb9f1a40ad9655bd818b5a73d0a68e355696425968cfb7cf56fb29d89fd5b"
   end
 
   on_intel do
-    url "https://github.com/iffse/pay-respects/releases/download/v0.7.10/pay-respects-0.7.10-x86_64-apple-darwin.tar.zst"
-    sha256 "d973fdb18eed4cd80bb5eb6289e780f1d5a0d24616ce9facc9ae8fc0c7fd26b5"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.7.11/pay-respects-0.7.11-x86_64-apple-darwin.tar.zst"
+    sha256 "d2af0b18a93626a5d36a2d7d500e259339a93286832c5870e72105f82826ec70"
   end
 
   def install

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ brew install timescam/tap/{formula}
 
 | Formula        | Version  | Description                                                                                                                                       |
 | -------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `pay-respects` | `0.7.10` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
+| `pay-respects` | `0.7.11` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
 | `localsend-go` | `1.2.7` | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
 | `imFile` | `1.1.2` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
 | `pokeget` | `1.6.7` | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |


### PR DESCRIPTION
Automated update of pay-respects to version 0.7.11

- Updated version to 0.7.11
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated download URLs to https://github.com/iffse/pay-respects/releases/download/v0.7.11/pay-respects-0.7.11-aarch64-apple-darwin.tar.zst and https://github.com/iffse/pay-respects/releases/download/v0.7.11/pay-respects-0.7.11-x86_64-apple-darwin.tar.zst
- Updated version in README.md