### PR TITLE
Update spotatui to version 0.35.7

### DIFF
--- a/Formula/spotatui.rb
+++ b/Formula/spotatui.rb
@@ -1,16 +1,16 @@
 class Spotatui < Formula
   desc "Spotify client for the terminal (Rust TUI, native streaming)"
   homepage "https://github.com/LargeModGames/spotatui"
-  version "0.35.6"
+  version "0.35.7"
 
   on_arm do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-aarch64.tar.gz"
-    sha256 "1c43a5c985502b7bdd3f66404f07f6a7ab39456ce7e058131c0141721550433d"
+    sha256 "86682e5f3de6f421f4fe42881ff86350857864f1a7fc5eea0b28b33c7abd6099"
   end
 
   on_intel do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-x86_64.tar.gz"
-    sha256 "fbab56d2b9c9dcded364033bdebf3c27d9f1f268797d728e3368bdfbac284796"
+    sha256 "5712796c81f8922bef5d7066c6c168299e5a3b251f7d822ae3f33bff549ee402"
   end
 
   def install

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ brew install timescam/tap/{formula}
 | `pokeget` | `1.6.7` | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |
 | `zagi` | `0.1.7` | A better git for z.<br />https://github.com/mattzcarey/zagi                                                                                       |
 | `gopeed-web` | `1.9.1` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed                    |
-| `spotatui` | `0.35.6` | A fully standalone Spotify client for the terminal. Native streaming included, no daemon required.<br />https://github.com/LargeModGames/spotatui |
+| `spotatui` | `0.35.7` | A fully standalone Spotify client for the terminal. Native streaming included, no daemon required.<br />https://github.com/LargeModGames/spotatui |
 
 ### Not tracked by daily GitHub Actions
 


### PR DESCRIPTION
Automated update of spotatui to version 0.35.7

- Updated version to 0.35.7
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md