### PR TITLE
Update spotatui to version 0.36.3-debug.1

### DIFF
--- a/Formula/spotatui.rb
+++ b/Formula/spotatui.rb
@@ -1,16 +1,16 @@
 class Spotatui < Formula
   desc "Spotify client for the terminal (Rust TUI, native streaming)"
   homepage "https://github.com/LargeModGames/spotatui"
-  version "0.36.2"
+  version "0.36.3-debug.1"
 
   on_arm do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-aarch64.tar.gz"
-    sha256 "a20e4f9c60625a91bd6c2e7d8eb8f72e7689f6eb48761f414fcabfafd9189f8a"
+    sha256 "f4145ba42ddea2045f7506d2b55afde600163ad2262c76bd52845785bdc93314"
   end
 
   on_intel do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-x86_64.tar.gz"
-    sha256 "c96b5ea6964aca71e4380315ad79ab515d543676a8326c3a777680120ceb92b0"
+    sha256 "6087b5a6eaa624eccfbd97f6897dacaad31586c3bd0809e7e3aedc2420081114"
   end
 
   def install

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ brew install timescam/tap/{formula}
 | `pokeget` | `1.6.7` | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |
 | `zagi` | `0.1.7` | A better git for z.<br />https://github.com/mattzcarey/zagi                                                                                       |
 | `gopeed-web` | `1.9.1` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed                    |
-| `spotatui` | `0.36.2` | A fully standalone Spotify client for the terminal. Native streaming included, no daemon required.<br />https://github.com/LargeModGames/spotatui |
+| `spotatui` | `0.36.3-debug.1` | A fully standalone Spotify client for the terminal. Native streaming included, no daemon required.<br />https://github.com/LargeModGames/spotatui |
 
 ### Not tracked by daily GitHub Actions
 


### PR DESCRIPTION
Automated update of spotatui to version 0.36.3-debug.1

- Updated version to 0.36.3-debug.1
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md