### PR TITLE
Update spotatui to version 0.37.0

### DIFF
--- a/Formula/spotatui.rb
+++ b/Formula/spotatui.rb
@@ -1,16 +1,16 @@
 class Spotatui < Formula
   desc "Spotify client for the terminal (Rust TUI, native streaming)"
   homepage "https://github.com/LargeModGames/spotatui"
-  version "0.36.3-debug.1"
+  version "0.37.0"
 
   on_arm do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-aarch64.tar.gz"
-    sha256 "f4145ba42ddea2045f7506d2b55afde600163ad2262c76bd52845785bdc93314"
+    sha256 "8aef4d5d96a89ccb38fe9df53be4b2645b6b3d8a1500999d04d24643d57b4eab"
   end
 
   on_intel do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-x86_64.tar.gz"
-    sha256 "6087b5a6eaa624eccfbd97f6897dacaad31586c3bd0809e7e3aedc2420081114"
+    sha256 "130a7cb716bdf3680e7695c4f3cd5cf7f4d945508052aca8cedb6b5f9bd033be"
   end
 
   def install


### PR DESCRIPTION
Automated update of spotatui to version 0.37.0

- Updated version to 0.37.0
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md