### PR TITLE
Update spotatui to version 0.37.1

### DIFF
--- a/Formula/spotatui.rb
+++ b/Formula/spotatui.rb
@@ -1,16 +1,16 @@
 class Spotatui < Formula
   desc "Spotify client for the terminal (Rust TUI, native streaming)"
   homepage "https://github.com/LargeModGames/spotatui"
-  version "0.37.0"
+  version "0.37.1"
 
   on_arm do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-aarch64.tar.gz"
-    sha256 "8aef4d5d96a89ccb38fe9df53be4b2645b6b3d8a1500999d04d24643d57b4eab"
+    sha256 "5a384a0a6b90ce4efd19f3aaa7f92990ccb2970a5982c31de70a739ae75add76"
   end
 
   on_intel do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-x86_64.tar.gz"
-    sha256 "130a7cb716bdf3680e7695c4f3cd5cf7f4d945508052aca8cedb6b5f9bd033be"
+    sha256 "2f80bb05600be4a1fff96b62592d7690e2ad745429dd85f976554e86323d6bde"
   end
 
   def install


### PR DESCRIPTION
Automated update of spotatui to version 0.37.1

- Updated version to 0.37.1
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md