### PR TITLE
Update spotatui to version 0.37.2

### DIFF
--- a/Formula/spotatui.rb
+++ b/Formula/spotatui.rb
@@ -1,16 +1,16 @@
 class Spotatui < Formula
   desc "Spotify client for the terminal (Rust TUI, native streaming)"
   homepage "https://github.com/LargeModGames/spotatui"
-  version "0.37.1"
+  version "0.37.2"
 
   on_arm do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-aarch64.tar.gz"
-    sha256 "5a384a0a6b90ce4efd19f3aaa7f92990ccb2970a5982c31de70a739ae75add76"
+    sha256 "b6e96a4351433b0c97b62ac68992123d5304162c8e5643bd2f60b56b51e01aac"
   end
 
   on_intel do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-x86_64.tar.gz"
-    sha256 "2f80bb05600be4a1fff96b62592d7690e2ad745429dd85f976554e86323d6bde"
+    sha256 "878b736d4a98200caf8bfef5c016bcf267555157c2632d7789f1f18d82f9ab7d"
   end
 
   def install


### PR DESCRIPTION
Automated update of spotatui to version 0.37.2

- Updated version to 0.37.2
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md