### PR TITLE
Update spotatui to version 0.37.3

### DIFF
--- a/Formula/spotatui.rb
+++ b/Formula/spotatui.rb
@@ -1,16 +1,16 @@
 class Spotatui < Formula
   desc "Spotify client for the terminal (Rust TUI, native streaming)"
   homepage "https://github.com/LargeModGames/spotatui"
-  version "0.37.2"
+  version "0.37.3"
 
   on_arm do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-aarch64.tar.gz"
-    sha256 "b6e96a4351433b0c97b62ac68992123d5304162c8e5643bd2f60b56b51e01aac"
+    sha256 "52f957f9cd58f7176d0b2419790beead3b6ad36f112d71ea65ad463a2a76262c"
   end
 
   on_intel do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-x86_64.tar.gz"
-    sha256 "878b736d4a98200caf8bfef5c016bcf267555157c2632d7789f1f18d82f9ab7d"
+    sha256 "986541f20736bf958edc011ac7b18fc7b0cecd819686739889ed043a0e9578ca"
   end
 
   def install


### PR DESCRIPTION
Automated update of spotatui to version 0.37.3

- Updated version to 0.37.3
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md