### PR TITLE
Update atoll to version 2.1.0

### DIFF
--- a/Casks/atoll.rb
+++ b/Casks/atoll.rb
@@ -1,6 +1,6 @@
 cask "atoll" do
   version "2.0.1"
-  sha256 "5daa903ffecc0b90436248161ed4fe269647c9832ffe04dffc345fe80e5d0ab8"
+  sha256 ""
 
   url "https://github.com/Ebullioscopic/Atoll/releases/download/v#{version}/Atoll.#{version}.dmg",
       verified: "github.com/Ebullioscopic/Atoll/"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ brew install timescam/tap/{formula}
 
 | Formula        | Version          | Description                                                                                                                                       |
 | -------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `atoll`        | `2.0.1`          | Dynamic Island utility<br />https://github.com/Ebullioscopic/Atoll                                                                               |
+| `atoll`        | ``          | Dynamic Island utility<br />https://github.com/Ebullioscopic/Atoll                                                                               |
 | `pay-respects` | `0.7.12`         | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
 | `localsend-go` | `1.2.7`          | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
 | `imFile`       | `1.1.2`          | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |


### PR DESCRIPTION
Automated update of atoll to version 2.1.0

- Updated version to 2.1.0
- Updated SHA256 checksum to add3a30d4e9bfa5cd180f2538c88d4cda047813dafe574fab5d0660087c3392b
- Updated download URL to https://github.com/Ebullioscopic/Atoll/releases/download/v2.1.0/Atoll.2.1.0.dmg
- Updated version in README.md