### PR TITLE
Update spotatui to version 0.38.0

### DIFF
--- a/Formula/spotatui.rb
+++ b/Formula/spotatui.rb
@@ -1,16 +1,16 @@
 class Spotatui < Formula
   desc "Spotify client for the terminal (Rust TUI, native streaming)"
   homepage "https://github.com/LargeModGames/spotatui"
-  version "0.37.3"
+  version "0.38.0"
 
   on_arm do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-aarch64.tar.gz"
-    sha256 "52f957f9cd58f7176d0b2419790beead3b6ad36f112d71ea65ad463a2a76262c"
+    sha256 "6fdeb1dda1dfb02f535d0a8df8a641f12ef909418931f69d5ed9e277b8364727"
   end
 
   on_intel do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-x86_64.tar.gz"
-    sha256 "986541f20736bf958edc011ac7b18fc7b0cecd819686739889ed043a0e9578ca"
+    sha256 "773b43525a0c98406189d68fddd477cb43e6740a10631b35e5eee4787099e910"
   end
 
   def install


### PR DESCRIPTION
Automated update of spotatui to version 0.38.0

- Updated version to 0.38.0
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md