### PR TITLE
Update imFile to version imFile-1.2.3

### DIFF
--- a/Casks/imfile.rb
+++ b/Casks/imfile.rb
@@ -1,7 +1,7 @@
 cask "imfile" do
   arch arm: "-arm64"
 
-  version "imFile-1.2.1"
+  version "imFile-1.2.3"
   sha256 arm:   "2db3324abda9aa072dab0eb6d38cf21329ad16de6b203feca74d42f5b398ee32",
          intel: "aa46960c8766a14cfc8c55571dcd407d0349af8de7f0f281ff6a15d4ac5bf7f0"
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ brew install timescam/tap/{formula}
 | `atoll`        | ``          | Dynamic Island utility<br />https://github.com/Ebullioscopic/Atoll                                                                               |
 | `pay-respects` | `0.8.0` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
 | `localsend-go` | `1.2.7`          | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
-| `imFile` | `imFile-1.2.1` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
+| `imFile` | `imFile-1.2.3` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
 | `pokeget`      | `1.6.7`          | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |
 | `zagi`         | `0.1.8`          | A better git for z.<br />https://github.com/mattzcarey/zagi                                                                                       |
 | `gopeed-web` | `1.9.3` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed                    |


### PR DESCRIPTION
Automated update of imFile to version imFile-1.2.3

- Updated version to imFile-1.2.3
- Updated SHA256 checksums for both ARM and Intel builds
- Updated download URLs to https://github.com/imfile-io/imfile-desktop/releases/download/imFile-1.2.3/imFile-1.2.3-arm64.dmg and https://github.com/imfile-io/imfile-desktop/releases/download/imFile-1.2.3/imFile-1.2.3.dmg
- Updated version in README.md