### PR TITLE
Update pay-respects to version 0.8.1

### DIFF
--- a/Formula/pay-respects.rb
+++ b/Formula/pay-respects.rb
@@ -1,16 +1,16 @@
 class PayRespects < Formula
   desc "CLI tool to pay respects"
   homepage "https://github.com/iffse/pay-respects"
-  version "0.8.0"
+  version "0.8.1"
 
   on_arm do
-    url "https://github.com/iffse/pay-respects/releases/download/v0.8.0/pay-respects-0.8.0-aarch64-apple-darwin.tar.zst"
-    sha256 "d2943b977855f2c94781ca697c21f50cebd3de6309e6a1b6d38e70c6d9173d56"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.8.1/pay-respects-0.8.1-aarch64-apple-darwin.tar.zst"
+    sha256 "64a777f9a1ec8d0ffd63e45600d242e6447e2c05d565d39ceccc984147d80d69"
   end
 
   on_intel do
-    url "https://github.com/iffse/pay-respects/releases/download/v0.8.0/pay-respects-0.8.0-x86_64-apple-darwin.tar.zst"
-    sha256 "97132ef20b14f2e637ad7fb93948b6025fe19b5b300bb39a9d653b326a349398"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.8.1/pay-respects-0.8.1-x86_64-apple-darwin.tar.zst"
+    sha256 "2c0e9e1b6f936e54ebbbf8b810a746e86cb420d972b760ff0fcea8aa55b71868"
   end
 
   def install

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ brew install timescam/tap/{formula}
 | Formula        | Version          | Description                                                                                                                                       |
 | -------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `atoll`        | ``          | Dynamic Island utility<br />https://github.com/Ebullioscopic/Atoll                                                                               |
-| `pay-respects` | `0.8.0` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
+| `pay-respects` | `0.8.1` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
 | `localsend-go` | `1.2.7`          | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
 | `imFile` | `imFile-1.2.3` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
 | `pokeget`      | `1.6.7`          | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |


### PR DESCRIPTION
Automated update of pay-respects to version 0.8.1

- Updated version to 0.8.1
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated download URLs to https://github.com/iffse/pay-respects/releases/download/v0.8.1/pay-respects-0.8.1-aarch64-apple-darwin.tar.zst and https://github.com/iffse/pay-respects/releases/download/v0.8.1/pay-respects-0.8.1-x86_64-apple-darwin.tar.zst
- Updated version in README.md