### PR TITLE
Update pay-respects to version 0.8.2

### DIFF
--- a/Formula/pay-respects.rb
+++ b/Formula/pay-respects.rb
@@ -1,16 +1,16 @@
 class PayRespects < Formula
   desc "CLI tool to pay respects"
   homepage "https://github.com/iffse/pay-respects"
-  version "0.8.1"
+  version "0.8.2"
 
   on_arm do
-    url "https://github.com/iffse/pay-respects/releases/download/v0.8.1/pay-respects-0.8.1-aarch64-apple-darwin.tar.zst"
-    sha256 "64a777f9a1ec8d0ffd63e45600d242e6447e2c05d565d39ceccc984147d80d69"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.8.2/pay-respects-0.8.2-aarch64-apple-darwin.tar.zst"
+    sha256 "fb1e67d2b977f426a44e79ed66abbdba0aceac320a134602b814b9da5a1eee95"
   end
 
   on_intel do
-    url "https://github.com/iffse/pay-respects/releases/download/v0.8.1/pay-respects-0.8.1-x86_64-apple-darwin.tar.zst"
-    sha256 "2c0e9e1b6f936e54ebbbf8b810a746e86cb420d972b760ff0fcea8aa55b71868"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.8.2/pay-respects-0.8.2-x86_64-apple-darwin.tar.zst"
+    sha256 "c44dc7131c95d33323a746efe6a61a780576a176f271fbabf76c1e6f5c59c76c"
   end
 
   def install

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ brew install timescam/tap/{formula}
 | Formula        | Version          | Description                                                                                                                                       |
 | -------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `atoll`        | ``          | Dynamic Island utility<br />https://github.com/Ebullioscopic/Atoll                                                                               |
-| `pay-respects` | `0.8.1` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
+| `pay-respects` | `0.8.2` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
 | `localsend-go` | `1.2.7`          | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
 | `imFile` | `imFile-1.2.3` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
 | `pokeget`      | `1.6.7`          | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |


### PR DESCRIPTION
Automated update of pay-respects to version 0.8.2

- Updated version to 0.8.2
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated download URLs to https://github.com/iffse/pay-respects/releases/download/v0.8.2/pay-respects-0.8.2-aarch64-apple-darwin.tar.zst and https://github.com/iffse/pay-respects/releases/download/v0.8.2/pay-respects-0.8.2-x86_64-apple-darwin.tar.zst
- Updated version in README.md