### PR TITLE
Update pay-respects to version 0.8.3

### DIFF
--- a/Formula/pay-respects.rb
+++ b/Formula/pay-respects.rb
@@ -1,16 +1,16 @@
 class PayRespects < Formula
   desc "CLI tool to pay respects"
   homepage "https://github.com/iffse/pay-respects"
-  version "0.8.2"
+  version "0.8.3"
 
   on_arm do
-    url "https://github.com/iffse/pay-respects/releases/download/v0.8.2/pay-respects-0.8.2-aarch64-apple-darwin.tar.zst"
-    sha256 "fb1e67d2b977f426a44e79ed66abbdba0aceac320a134602b814b9da5a1eee95"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.8.3/pay-respects-0.8.3-aarch64-apple-darwin.tar.zst"
+    sha256 "dd31b0738d8130bd95b318e6ca834332021f70711513077035c84ed2fadef90c"
   end
 
   on_intel do
-    url "https://github.com/iffse/pay-respects/releases/download/v0.8.2/pay-respects-0.8.2-x86_64-apple-darwin.tar.zst"
-    sha256 "c44dc7131c95d33323a746efe6a61a780576a176f271fbabf76c1e6f5c59c76c"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.8.3/pay-respects-0.8.3-x86_64-apple-darwin.tar.zst"
+    sha256 "3784af5fd84a1f719d7cbe486d5097e57f6d054ba5450dff872efa9e848d6a18"
   end
 
   def install

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ brew install timescam/tap/{formula}
 | Formula        | Version          | Description                                                                                                                                       |
 | -------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `atoll`        | ``          | Dynamic Island utility<br />https://github.com/Ebullioscopic/Atoll                                                                               |
-| `pay-respects` | `0.8.2` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
+| `pay-respects` | `0.8.3` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
 | `localsend-go` | `1.2.7`          | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
 | `imFile` | `2.0.0` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
 | `pokeget`      | `1.6.7`          | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |


### PR DESCRIPTION
Automated update of pay-respects to version 0.8.3

- Updated version to 0.8.3
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated download URLs to https://github.com/iffse/pay-respects/releases/download/v0.8.3/pay-respects-0.8.3-aarch64-apple-darwin.tar.zst and https://github.com/iffse/pay-respects/releases/download/v0.8.3/pay-respects-0.8.3-x86_64-apple-darwin.tar.zst
- Updated version in README.md