### PR TITLE
Update pay-respects to version 0.8.5

### DIFF
--- a/Formula/pay-respects.rb
+++ b/Formula/pay-respects.rb
@@ -1,16 +1,16 @@
 class PayRespects < Formula
   desc "CLI tool to pay respects"
   homepage "https://github.com/iffse/pay-respects"
-  version "0.8.4"
+  version "0.8.5"
 
   on_arm do
-    url "https://github.com/iffse/pay-respects/releases/download/v0.8.4/pay-respects-0.8.4-aarch64-apple-darwin.tar.zst"
-    sha256 "0375b3db96ec0a1f8c98d4171d578281185840688e53585245ef54ceb7084e88"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.8.5/pay-respects-0.8.5-aarch64-apple-darwin.tar.zst"
+    sha256 "38c1fc85f42a35adbdaee3d8b1828abbdfec2f9f711937dea36363290bb1d468"
   end
 
   on_intel do
-    url "https://github.com/iffse/pay-respects/releases/download/v0.8.4/pay-respects-0.8.4-x86_64-apple-darwin.tar.zst"
-    sha256 "faffcad6d2717229ba4ec541c67e7a3a3d68b0f02fe1d1e6910d07fe21c7ba2d"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.8.5/pay-respects-0.8.5-x86_64-apple-darwin.tar.zst"
+    sha256 "6a56881816e630f73eaf4dac92ef113145b337ee66c59b9da0b09201eedf71f4"
   end
 
   def install

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ brew install timescam/tap/{formula}
 | Formula        | Version          | Description                                                                                                                                       |
 | -------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `atoll`        | ``          | Dynamic Island utility<br />https://github.com/Ebullioscopic/Atoll                                                                               |
-| `pay-respects` | `0.8.4` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
+| `pay-respects` | `0.8.5` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
 | `localsend-go` | `1.2.7`          | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
 | `imFile` | `2.0.3` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
 | `pokeget`      | `1.6.7`          | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |


### PR DESCRIPTION
Automated update of pay-respects to version 0.8.5

- Updated version to 0.8.5
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated download URLs to https://github.com/iffse/pay-respects/releases/download/v0.8.5/pay-respects-0.8.5-aarch64-apple-darwin.tar.zst and https://github.com/iffse/pay-respects/releases/download/v0.8.5/pay-respects-0.8.5-x86_64-apple-darwin.tar.zst
- Updated version in README.md