### PR TITLE
Update koharu to version 0.44.1

### DIFF
--- a/Casks/koharu.rb
+++ b/Casks/koharu.rb
@@ -1,6 +1,6 @@
 cask "koharu" do
-  version "0.43.2"
-  sha256 "64213cb0fbbca5288d0d8b5f1f1cb01332fe2cdb1c773f5d6d650902c4ab10f7"
+  version ""
+  sha256 ""
 
   url "https://github.com/mayocream/koharu/releases/download/#{version}/koharu_#{version}_aarch64.dmg",
       verified: "github.com/mayocream/koharu/"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ brew install timescam/tap/{formula}
 | `pay-respects` | `0.8.5` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
 | `localsend-go` | `1.2.7`          | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
 | `imFile` | `2.0.5` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
-| `koharu` | `0.43.2` | ML-powered manga translator.<br />https://github.com/mayocream/koharu                                                                             |
+| `koharu` | `` | ML-powered manga translator.<br />https://github.com/mayocream/koharu                                                                             |
 | `pokeget`      | `1.6.7`          | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |
 | `zagi` | `0.2.0` | A better git for z.<br />https://github.com/mattzcarey/zagi                                                                                       |
 | `gopeed-web` | `1.9.3` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed                    |


### PR DESCRIPTION
Automated update of koharu to version 0.44.1

- Updated version to 0.44.1
- Updated SHA256 checksum to 1383f7de437d55b598d6a13833125a99e8c374dc24162f3a9e31c0191976bbcc
- Updated download URL to https://github.com/mayocream/koharu/releases/download/0.44.1/koharu_0.44.1_aarch64.dmg
- Updated version in README.md