### PR TITLE
Update koharu to version 0.44.5

### DIFF
--- a/Casks/koharu.rb
+++ b/Casks/koharu.rb
@@ -1,6 +1,6 @@
 cask "koharu" do
-  version "0.44.2"
-  sha256 "0e88daac0ff0a75a310db056fadc15076f6e8fe64857337ace83d3ecbfc50676"
+  version "0.44.5"
+  sha256 "895f61ee07a9a2a1c5c17841aa02174c7cd68346e2a45e7becde7dc6b4203e9c"
 
   url "https://github.com/mayocream/koharu/releases/download/#{version}/koharu_#{version}_aarch64.dmg",
       verified: "github.com/mayocream/koharu/"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ brew install timescam/tap/{formula}
 | `pay-respects` | `0.8.5` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
 | `localsend-go` | `1.2.7`          | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
 | `imFile` | `2.0.5` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
-| `koharu` | `0.44.2` | ML-powered manga translator.<br />https://github.com/mayocream/koharu                                                                             |
+| `koharu` | `0.44.5` | ML-powered manga translator.<br />https://github.com/mayocream/koharu                                                                             |
 | `motrix-next` | `3.6.10` | Modern Tauri-based download manager for macOS.<br />https://github.com/AnInsomniacy/motrix-next                                                  |
 | `pokeget`      | `1.6.7`          | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |
 | `zagi` | `0.2.0` | A better git for z.<br />https://github.com/mattzcarey/zagi                                                                                       |


### PR DESCRIPTION
Automated update of koharu to version 0.44.5

- Updated version to 0.44.5
- Updated SHA256 checksum to 895f61ee07a9a2a1c5c17841aa02174c7cd68346e2a45e7becde7dc6b4203e9c
- Updated download URL to https://github.com/mayocream/koharu/releases/download/0.44.5/koharu_0.44.5_aarch64.dmg
- Updated version in README.md