### PR TITLE
Update atoll to version 2.1.0

### DIFF
--- a/Casks/atoll.rb
+++ b/Casks/atoll.rb
@@ -1,5 +1,5 @@
 cask "atoll" do
-  version "2.0.1"
+  version "2.1.0"
   sha256 ""
 
   url "https://github.com/Ebullioscopic/Atoll/releases/download/v#{version}/Atoll.#{version}.dmg",


### PR DESCRIPTION
Automated update of atoll to version 2.1.0

- Updated version to 2.1.0
- Updated SHA256 checksum to add3a30d4e9bfa5cd180f2538c88d4cda047813dafe574fab5d0660087c3392b
- Updated download URL to https://github.com/Ebullioscopic/Atoll/releases/download/v2.1.0/Atoll.2.1.0.dmg
- Updated version in README.md