### PR TITLE
Update motrix-next to version 3.7.1

### DIFF
--- a/Casks/motrix-next.rb
+++ b/Casks/motrix-next.rb
@@ -1,14 +1,14 @@
 cask "motrix-next" do
-  version "3.7.0"
+  version "3.7.1"
 
   on_arm do
-    sha256 "93d6ae5b73db14a098aa50790c9a84dbcbd43498d962aba900ad50db56076dd9"
+    sha256 "63ff44ab15aba75700883a78b45a1e250c8e7369a4e73a05a23666e906395b97"
 
     url "https://github.com/AnInsomniacy/motrix-next/releases/download/v#{version}/MotrixNext_#{version}_aarch64.dmg",
         verified: "github.com/AnInsomniacy/motrix-next/"
   end
   on_intel do
-    sha256 "8300cfce85472fedcb759c3b64b093f4d5b3f7a30e7d50e8c75e1de8b8918984"
+    sha256 "ede42ddbd4572142452d513ae322b2f7ed6a03c4ee0cabfbb93c3197500090b4"
 
     url "https://github.com/AnInsomniacy/motrix-next/releases/download/v#{version}/MotrixNext_#{version}_x64.dmg",
         verified: "github.com/AnInsomniacy/motrix-next/"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ brew install timescam/tap/{formula}
 | `localsend-go` | `1.2.7`          | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
 | `imFile` | `2.0.5` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
 | `koharu` | `0.44.6` | ML-powered manga translator.<br />https://github.com/mayocream/koharu                                                                             |
-| `motrix-next` | `3.7.0` | Modern Tauri-based download manager for macOS.<br />https://github.com/AnInsomniacy/motrix-next                                                  |
+| `motrix-next` | `3.7.1` | Modern Tauri-based download manager for macOS.<br />https://github.com/AnInsomniacy/motrix-next                                                  |
 | `pokeget`      | `1.6.7`          | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |
 | `zagi` | `0.2.0` | A better git for z.<br />https://github.com/mattzcarey/zagi                                                                                       |
 | `gopeed-web` | `1.9.3` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed                    |


### PR DESCRIPTION
Automated update of motrix-next to version 3.7.1

- Updated version to 3.7.1
- Updated SHA256 checksums for both ARM and Intel builds
- Validated download assets at https://github.com/AnInsomniacy/motrix-next/releases/download/v3.7.1/MotrixNext_3.7.1_aarch64.dmg and https://github.com/AnInsomniacy/motrix-next/releases/download/v3.7.1/MotrixNext_3.7.1_x64.dmg
- Updated version in README.md