### PR TITLE
Update koharu to version 0.45.3

### DIFF
--- a/Casks/koharu.rb
+++ b/Casks/koharu.rb
@@ -1,6 +1,6 @@
 cask "koharu" do
-  version "0.44.6"
-  sha256 "8195e006d490c9c1d18e14d38fcd2189ebc9a4f9a831c78ac2a2273ca87a9e08"
+  version "0.45.3"
+  sha256 "6fcf06e81ea150c4c509e62f157a3e36996613b52f014846a87096a428d7df02"
 
   url "https://github.com/mayocream/koharu/releases/download/#{version}/koharu_#{version}_aarch64.dmg",
       verified: "github.com/mayocream/koharu/"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ brew install timescam/tap/{formula}
 | `pay-respects` | `0.8.5` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
 | `localsend-go` | `1.2.7`          | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
 | `imFile` | `2.0.5` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
-| `koharu` | `0.44.6` | ML-powered manga translator.<br />https://github.com/mayocream/koharu                                                                             |
+| `koharu` | `0.45.3` | ML-powered manga translator.<br />https://github.com/mayocream/koharu                                                                             |
 | `motrix-next` | `3.7.1` | Modern Tauri-based download manager for macOS.<br />https://github.com/AnInsomniacy/motrix-next                                                  |
 | `pokeget`      | `1.6.7`          | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |
 | `zagi` | `0.2.0` | A better git for z.<br />https://github.com/mattzcarey/zagi                                                                                       |


### PR DESCRIPTION
Automated update of koharu to version 0.45.3

- Updated version to 0.45.3
- Updated SHA256 checksum to 6fcf06e81ea150c4c509e62f157a3e36996613b52f014846a87096a428d7df02
- Updated download URL to https://github.com/mayocream/koharu/releases/download/0.45.3/koharu_0.45.3_aarch64.dmg
- Updated version in README.md