### PR TITLE
Update koharu to version 0.47.7

### DIFF
--- a/Casks/koharu.rb
+++ b/Casks/koharu.rb
@@ -1,6 +1,6 @@
 cask "koharu" do
-  version "0.47.4"
-  sha256 "6fc64eafc411fa16e52e2c4de45cb980e35bd3f5e6677e82223e023ecd746c1e"
+  version "0.47.7"
+  sha256 "63692937ec60d68cede960b799f1c1998fcaf31331c14fef8f665e66d762287f"
 
   url "https://github.com/mayocream/koharu/releases/download/#{version}/koharu_#{version}_aarch64.dmg",
       verified: "github.com/mayocream/koharu/"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ brew install timescam/tap/{formula}
 | `pay-respects` | `0.8.5` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
 | `localsend-go` | `1.2.7`          | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
 | `imFile` | `2.0.5` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
-| `koharu` | `0.47.4` | ML-powered manga translator.<br />https://github.com/mayocream/koharu                                                                             |
+| `koharu` | `0.47.7` | ML-powered manga translator.<br />https://github.com/mayocream/koharu                                                                             |
 | `motrix-next` | `3.8.0` | Modern Tauri-based download manager for macOS.<br />https://github.com/AnInsomniacy/motrix-next                                                  |
 | `pokeget`      | `1.6.7`          | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |
 | `zagi` | `0.2.0` | A better git for z.<br />https://github.com/mattzcarey/zagi                                                                                       |


### PR DESCRIPTION
Automated update of koharu to version 0.47.7

- Updated version to 0.47.7
- Updated SHA256 checksum to 63692937ec60d68cede960b799f1c1998fcaf31331c14fef8f665e66d762287f
- Updated download URL to https://github.com/mayocream/koharu/releases/download/0.47.7/koharu_0.47.7_aarch64.dmg
- Updated version in README.md