### PR TITLE
Update motrix-next to version 3.8.3

### DIFF
--- a/Casks/motrix-next.rb
+++ b/Casks/motrix-next.rb
@@ -1,14 +1,14 @@
 cask "motrix-next" do
-  version "3.8.2"
+  version "3.8.3"
 
   on_arm do
-    sha256 "a62c57c6c98be07f71e1575a1dca3a9e51df70428989b80c7b7e5c1b072f30ad"
+    sha256 "2aa6c8af895acafa9b9980bdc8037125b980d7751f452587df675c37e689fe48"
 
     url "https://github.com/AnInsomniacy/motrix-next/releases/download/v#{version}/MotrixNext_#{version}_aarch64.dmg",
         verified: "github.com/AnInsomniacy/motrix-next/"
   end
   on_intel do
-    sha256 "29a34d4bbf0fa1ca003581f4e61acc029c635a6c4fe937ce7deafa8953b3a70b"
+    sha256 "5c239ce03b555ae114e6a65f5b66c87ed3c9c0cf4aa1f00ca7e0a4e3d1389323"
 
     url "https://github.com/AnInsomniacy/motrix-next/releases/download/v#{version}/MotrixNext_#{version}_x64.dmg",
         verified: "github.com/AnInsomniacy/motrix-next/"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ brew install timescam/tap/{formula}
 | `localsend-go` | `1.2.7`          | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
 | `imFile` | `2.0.5` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
 | `koharu` | `0.48.0` | ML-powered manga translator.<br />https://github.com/mayocream/koharu                                                                             |
-| `motrix-next` | `3.8.2` | Modern Tauri-based download manager for macOS.<br />https://github.com/AnInsomniacy/motrix-next                                                  |
+| `motrix-next` | `3.8.3` | Modern Tauri-based download manager for macOS.<br />https://github.com/AnInsomniacy/motrix-next                                                  |
 | `pokeget`      | `1.6.7`          | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |
 | `zagi` | `0.2.0` | A better git for z.<br />https://github.com/mattzcarey/zagi                                                                                       |
 | `gopeed-web` | `1.9.3` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed                    |


### PR DESCRIPTION
Automated update of motrix-next to version 3.8.3

- Updated version to 3.8.3
- Updated SHA256 checksums for both ARM and Intel builds
- Validated download assets at https://github.com/AnInsomniacy/motrix-next/releases/download/v3.8.3/MotrixNext_3.8.3_aarch64.dmg and https://github.com/AnInsomniacy/motrix-next/releases/download/v3.8.3/MotrixNext_3.8.3_x64.dmg
- Updated version in README.md