### PR TITLE
Update spotatui to version 0.38.1

### DIFF
--- a/Formula/spotatui.rb
+++ b/Formula/spotatui.rb
@@ -1,16 +1,16 @@
 class Spotatui < Formula
   desc "Spotify client for the terminal (Rust TUI, native streaming)"
   homepage "https://github.com/LargeModGames/spotatui"
-  version "0.38.0"
+  version "0.38.1"
 
   on_arm do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-aarch64.tar.gz"
-    sha256 "6fdeb1dda1dfb02f535d0a8df8a641f12ef909418931f69d5ed9e277b8364727"
+    sha256 "daa4e24c6eff5eaafd052f65b947b596d4f2da05229df776dd499b5284f4472f"
   end
 
   on_intel do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-x86_64.tar.gz"
-    sha256 "773b43525a0c98406189d68fddd477cb43e6740a10631b35e5eee4787099e910"
+    sha256 "b9d4f7b0068a8b982c6cb76ac330df2fda4c4ebee0099270b42aa5bbab666df1"
   end
 
   def install


### PR DESCRIPTION
Automated update of spotatui to version 0.38.1

- Updated version to 0.38.1
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md