### PR TITLE
Update pay-respects to version 0.8.7

### DIFF
--- a/Formula/pay-respects.rb
+++ b/Formula/pay-respects.rb
@@ -1,16 +1,16 @@
 class PayRespects < Formula
   desc "CLI tool to pay respects"
   homepage "https://github.com/iffse/pay-respects"
-  version "nightly"
+  version "0.8.7"
 
   on_arm do
-    url "https://github.com/iffse/pay-respects/releases/download/nightly/pay-respects-nightly-aarch64-apple-darwin.tar.zst"
-    sha256 "c9baaa4765f26170a53aad556d814a8a9dea28fbbd3a89d1e823e193cf6cd990"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.8.7/pay-respects-0.8.7-aarch64-apple-darwin.tar.zst"
+    sha256 "c9e31dfd6d541294f7120100d678083b1bb9e61dc7b2d2257ac6ea8b4df34738"
   end
 
   on_intel do
-    url "https://github.com/iffse/pay-respects/releases/download/nightly/pay-respects-nightly-x86_64-apple-darwin.tar.zst"
-    sha256 "5230e2287f436e6a0a72086820f454c1b4462ce931c5a5b258c65c8c2e3c4624"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.8.7/pay-respects-0.8.7-x86_64-apple-darwin.tar.zst"
+    sha256 "9ccd3634941ae392124984160af20cb66e851d5cc8a12fd6a472634224a957da"
   end
 
   def install


### PR DESCRIPTION
Automated update of pay-respects to version 0.8.7

- Updated version to 0.8.7
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated download URLs to https://github.com/iffse/pay-respects/releases/download/v0.8.7/pay-respects-0.8.7-aarch64-apple-darwin.tar.zst and https://github.com/iffse/pay-respects/releases/download/v0.8.7/pay-respects-0.8.7-x86_64-apple-darwin.tar.zst
- Updated version in README.md