### PR TITLE
Update pay-respects to version 0.8.8

### DIFF
--- a/Formula/pay-respects.rb
+++ b/Formula/pay-respects.rb
@@ -1,16 +1,16 @@
 class PayRespects < Formula
   desc "CLI tool to pay respects"
   homepage "https://github.com/iffse/pay-respects"
-  version "0.8.7"
+  version "0.8.8"
 
   on_arm do
-    url "https://github.com/iffse/pay-respects/releases/download/v0.8.7/pay-respects-0.8.7-aarch64-apple-darwin.tar.zst"
-    sha256 "c9e31dfd6d541294f7120100d678083b1bb9e61dc7b2d2257ac6ea8b4df34738"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.8.8/pay-respects-0.8.8-aarch64-apple-darwin.tar.zst"
+    sha256 "e834e928dcaf9cd72a99478bb61e0630ba76e32c7b228eb3a7be9c5f404cd548"
   end
 
   on_intel do
-    url "https://github.com/iffse/pay-respects/releases/download/v0.8.7/pay-respects-0.8.7-x86_64-apple-darwin.tar.zst"
-    sha256 "9ccd3634941ae392124984160af20cb66e851d5cc8a12fd6a472634224a957da"
+    url "https://github.com/iffse/pay-respects/releases/download/v0.8.8/pay-respects-0.8.8-x86_64-apple-darwin.tar.zst"
+    sha256 "64c30e1a62605279abf219193c53bf251687ea419a0c99d2e15ae8b5b6a58587"
   end
 
   def install


### PR DESCRIPTION
Automated update of pay-respects to version 0.8.8

- Updated version to 0.8.8
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated download URLs to https://github.com/iffse/pay-respects/releases/download/v0.8.8/pay-respects-0.8.8-aarch64-apple-darwin.tar.zst and https://github.com/iffse/pay-respects/releases/download/v0.8.8/pay-respects-0.8.8-x86_64-apple-darwin.tar.zst
- Updated version in README.md