### PR TITLE
Update motrix-next to version 3.8.8

### DIFF
--- a/Casks/motrix-next.rb
+++ b/Casks/motrix-next.rb
@@ -1,14 +1,14 @@
 cask "motrix-next" do
-  version "3.8.7"
+  version "3.8.8"
 
   on_arm do
-    sha256 "e1992e1165ec4c59bf3d9a78451ea6de11ed08f3cb9173e7787afb4ecfa54790"
+    sha256 "bb99f4b355160fea06ee1c356dfd0010eaa32e07d269415f5698e35c3a470fbf"
 
     url "https://github.com/AnInsomniacy/motrix-next/releases/download/v#{version}/MotrixNext_#{version}_aarch64.dmg",
         verified: "github.com/AnInsomniacy/motrix-next/"
   end
   on_intel do
-    sha256 "050aa0ee4eea6994c85219b0933c5e2b2acedca27c2e1a7e59041baa0ab9b182"
+    sha256 "47a0ca4ac2d3e5883d225b3a8cad6f6b0703beefc4d67a669fa823415bdfd868"
 
     url "https://github.com/AnInsomniacy/motrix-next/releases/download/v#{version}/MotrixNext_#{version}_x64.dmg",
         verified: "github.com/AnInsomniacy/motrix-next/"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ brew install timescam/tap/{formula}
 | `localsend-go` | `1.2.7`          | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
 | `imFile` | `2.0.5` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
 | `koharu` | `0.58.0` | ML-powered manga translator.<br />https://github.com/mayocream/koharu                                                                             |
-| `motrix-next` | `3.8.7` | Modern Tauri-based download manager for macOS.<br />https://github.com/AnInsomniacy/motrix-next                                                  |
+| `motrix-next` | `3.8.8` | Modern Tauri-based download manager for macOS.<br />https://github.com/AnInsomniacy/motrix-next                                                  |
 | `pokeget`      | `1.6.7`          | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |
 | `zagi` | `0.2.0` | A better git for z.<br />https://github.com/mattzcarey/zagi                                                                                       |
 | `gopeed-web` | `1.9.3` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed                    |


### PR DESCRIPTION
Automated update of motrix-next to version 3.8.8

- Updated version to 3.8.8
- Updated SHA256 checksums for both ARM and Intel builds
- Validated download assets at https://github.com/AnInsomniacy/motrix-next/releases/download/v3.8.8/MotrixNext_3.8.8_aarch64.dmg and https://github.com/AnInsomniacy/motrix-next/releases/download/v3.8.8/MotrixNext_3.8.8_x64.dmg
- Updated version in README.md