### PR TITLE
Update spotatui to version 0.38.2

### DIFF
--- a/Formula/spotatui.rb
+++ b/Formula/spotatui.rb
@@ -1,16 +1,16 @@
 class Spotatui < Formula
   desc "Spotify client for the terminal (Rust TUI, native streaming)"
   homepage "https://github.com/LargeModGames/spotatui"
-  version "0.38.1"
+  version "0.38.2"
 
   on_arm do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-aarch64.tar.gz"
-    sha256 "daa4e24c6eff5eaafd052f65b947b596d4f2da05229df776dd499b5284f4472f"
+    sha256 "3f6be7d347a0336d7d8408c5480c772a7206e5e503dec3da4007ad44505d65cc"
   end
 
   on_intel do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-x86_64.tar.gz"
-    sha256 "b9d4f7b0068a8b982c6cb76ac330df2fda4c4ebee0099270b42aa5bbab666df1"
+    sha256 "7762eece774a20fbcce06ad29642714fdab3ca20caed7236344b8c2d8a20dbb0"
   end
 
   def install


### PR DESCRIPTION
Automated update of spotatui to version 0.38.2

- Updated version to 0.38.2
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md