### PR TITLE
Update motrix-next to version 3.8.10

### DIFF
--- a/Casks/motrix-next.rb
+++ b/Casks/motrix-next.rb
@@ -1,14 +1,14 @@
 cask "motrix-next" do
-  version "3.8.9"
+  version "3.8.10"
 
   on_arm do
-    sha256 "46b867eb055a70b9ab47ab188f11a4d6535dc7dd92e5c8511da592206ee0a435"
+    sha256 "59151b33224ac76d4016484ea0d32e501819fbebc5f13bbfe89aa8bd34b749e6"
 
     url "https://github.com/AnInsomniacy/motrix-next/releases/download/v#{version}/MotrixNext_#{version}_aarch64.dmg",
         verified: "github.com/AnInsomniacy/motrix-next/"
   end
   on_intel do
-    sha256 "b41ba69bba220f82b205c82100f80976d2d5c00378707b5ed18184f6dd44db51"
+    sha256 "298b146c67d4c3d5d58d63c75ef387f89f854973871121c07b4bdc3d8f0256e0"
 
     url "https://github.com/AnInsomniacy/motrix-next/releases/download/v#{version}/MotrixNext_#{version}_x64.dmg",
         verified: "github.com/AnInsomniacy/motrix-next/"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ brew install timescam/tap/{formula}
 | `localsend-go` | `1.2.7`          | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
 | `imFile` | `2.0.5` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
 | `koharu` | `0.59.1` | ML-powered manga translator.<br />https://github.com/mayocream/koharu                                                                             |
-| `motrix-next` | `3.8.9` | Modern Tauri-based download manager for macOS.<br />https://github.com/AnInsomniacy/motrix-next                                                  |
+| `motrix-next` | `3.8.10` | Modern Tauri-based download manager for macOS.<br />https://github.com/AnInsomniacy/motrix-next                                                  |
 | `pokeget`      | `1.6.7`          | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |
 | `zagi` | `0.2.0` | A better git for z.<br />https://github.com/mattzcarey/zagi                                                                                       |
 | `gopeed-web` | `1.9.3` | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed                    |


### PR DESCRIPTION
Automated update of motrix-next to version 3.8.10

- Updated version to 3.8.10
- Updated SHA256 checksums for both ARM and Intel builds
- Validated download assets at https://github.com/AnInsomniacy/motrix-next/releases/download/v3.8.10/MotrixNext_3.8.10_aarch64.dmg and https://github.com/AnInsomniacy/motrix-next/releases/download/v3.8.10/MotrixNext_3.8.10_x64.dmg
- Updated version in README.md