### PR TITLE
Update spotatui to version 0.38.4

### DIFF
--- a/Formula/spotatui.rb
+++ b/Formula/spotatui.rb
@@ -1,16 +1,16 @@
 class Spotatui < Formula
   desc "Spotify client for the terminal (Rust TUI, native streaming)"
   homepage "https://github.com/LargeModGames/spotatui"
-  version "0.38.3"
+  version "0.38.4"
 
   on_arm do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-aarch64.tar.gz"
-    sha256 "3b6c5e51762588f0eb62ea6bcea549aba06f95b9d43db707b2eb90b62641ed34"
+    sha256 "8ddd776d7b5aa7e5177b4cab6c99e3434a678ac59b386fda154d95f5b15d59aa"
   end
 
   on_intel do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-x86_64.tar.gz"
-    sha256 "708e0c1b50c995a490af4851d9dec581187fac2a8e71ef23885ef13b5b5de37e"
+    sha256 "a3f2d2b8aa7b8c66b0323e44536b759235d485508c68a8ccb3451f752f65d199"
   end
 
   def install


### PR DESCRIPTION
Automated update of spotatui to version 0.38.4

- Updated version to 0.38.4
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md