### PR TITLE
Update spotatui to version 0.38.6

### DIFF
--- a/Formula/spotatui.rb
+++ b/Formula/spotatui.rb
@@ -1,16 +1,16 @@
 class Spotatui < Formula
   desc "Spotify client for the terminal (Rust TUI, native streaming)"
   homepage "https://github.com/LargeModGames/spotatui"
-  version "0.38.4"
+  version "0.38.6"
 
   on_arm do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-aarch64.tar.gz"
-    sha256 "8ddd776d7b5aa7e5177b4cab6c99e3434a678ac59b386fda154d95f5b15d59aa"
+    sha256 "4194bec88568fe17a2cd165bdf3e415988f11fb6a12e865005cea421c4a70be9"
   end
 
   on_intel do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-x86_64.tar.gz"
-    sha256 "a3f2d2b8aa7b8c66b0323e44536b759235d485508c68a8ccb3451f752f65d199"
+    sha256 "5a014141f39333868623469074ff80eaafa5eed0ad99d0485d2198b0f530ff9d"
   end
 
   def install


### PR DESCRIPTION
Automated update of spotatui to version 0.38.6

- Updated version to 0.38.6
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md