### PR TITLE
Update koharu to version 0.60.0

### DIFF
--- a/Casks/koharu.rb
+++ b/Casks/koharu.rb
@@ -1,6 +1,6 @@
 cask "koharu" do
-  version "0.59.2"
-  sha256 "34cef56cd507bad441e0a813b348e490a4094f04bf34e1df485292701bbf732a"
+  version "0.60.0"
+  sha256 "27e59ffe4d7cb4fd6b7225722e7aa2412e5a8e888d651877ce5a6ec07d35ddea"
 
   url "https://github.com/mayocream/koharu/releases/download/#{version}/koharu_#{version}_aarch64.dmg",
       verified: "github.com/mayocream/koharu/"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ brew install --cask timescam/tap/{cask}
 | `pay-respects` | `nightly` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
 | `localsend-go` | `1.2.7`          | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
 | `imFile` | `2.0.5` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
-| `koharu` | `0.59.2` | ML-powered manga translator.<br />https://github.com/mayocream/koharu                                                                             |
+| `koharu` | `0.60.0` | ML-powered manga translator.<br />https://github.com/mayocream/koharu                                                                             |
 | `motrix-next` | `3.9.4` | Modern Tauri-based download manager for macOS.<br />https://github.com/AnInsomniacy/motrix-next                                                  |
 | `pokeget`      | `1.6.7`          | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |
 | `zagi` | `0.2.0` | A better git for z.<br />https://github.com/mattzcarey/zagi                                                                                       |


### PR DESCRIPTION
Automated update of koharu to version 0.60.0

- Updated version to 0.60.0
- Updated SHA256 checksum to 27e59ffe4d7cb4fd6b7225722e7aa2412e5a8e888d651877ce5a6ec07d35ddea
- Updated download URL to https://github.com/mayocream/koharu/releases/download/0.60.0/koharu_0.60.0_aarch64.dmg
- Updated version in README.md