### PR TITLE
Update spotatui to version 0.39.1

### DIFF
--- a/Formula/spotatui.rb
+++ b/Formula/spotatui.rb
@@ -1,16 +1,16 @@
 class Spotatui < Formula
   desc "Spotify client for the terminal (Rust TUI, native streaming)"
   homepage "https://github.com/LargeModGames/spotatui"
-  version "0.38.6"
+  version "0.39.1"
 
   on_arm do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-aarch64.tar.gz"
-    sha256 "4194bec88568fe17a2cd165bdf3e415988f11fb6a12e865005cea421c4a70be9"
+    sha256 "c95651b45b85eb43800d63d63d1b5595e4caf55a683194d0a02ed41f29970956"
   end
 
   on_intel do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-x86_64.tar.gz"
-    sha256 "5a014141f39333868623469074ff80eaafa5eed0ad99d0485d2198b0f530ff9d"
+    sha256 "874e4c96997b619beaef67abc29b82f6aba8e703bc4ebd7c65796d788b5d00b1"
   end
 
   def install


### PR DESCRIPTION
Automated update of spotatui to version 0.39.1

- Updated version to 0.39.1
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md