### PR TITLE
Update koharu to version 0.61.2

### DIFF
--- a/Casks/koharu.rb
+++ b/Casks/koharu.rb
@@ -1,6 +1,6 @@
 cask "koharu" do
-  version "0.61.1"
-  sha256 "a4a4c1cdb48ce1c9b49cd24246331e86d490d07006b9d5c5d4efbc32c869ad31"
+  version "0.61.2"
+  sha256 "915da65d5d093061757994c25ebf429b421fe6518ec666e7531f35bf63729c14"
 
   url "https://github.com/mayocream/koharu/releases/download/#{version}/koharu_#{version}_aarch64.dmg",
       verified: "github.com/mayocream/koharu/"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ brew install --cask timescam/tap/{cask}
 | `pay-respects` | `nightly` | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
 | `localsend-go` | `1.2.7`          | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
 | `imFile` | `2.0.5` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
-| `koharu` | `0.61.1` | ML-powered manga translator.<br />https://github.com/mayocream/koharu                                                                             |
+| `koharu` | `0.61.2` | ML-powered manga translator.<br />https://github.com/mayocream/koharu                                                                             |
 | `motrix-next` | `3.9.4` | Modern Tauri-based download manager for macOS.<br />https://github.com/AnInsomniacy/motrix-next                                                  |
 | `pokeget`      | `1.6.7`          | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |
 | `zagi` | `0.2.0` | A better git for z.<br />https://github.com/mattzcarey/zagi                                                                                       |


### PR DESCRIPTION
Automated update of koharu to version 0.61.2

- Updated version to 0.61.2
- Updated SHA256 checksum to 915da65d5d093061757994c25ebf429b421fe6518ec666e7531f35bf63729c14
- Updated download URL to https://github.com/mayocream/koharu/releases/download/0.61.2/koharu_0.61.2_aarch64.dmg
- Updated version in README.md