### PR TITLE
Update spotatui to version 0.40.1

### DIFF
--- a/Formula/spotatui.rb
+++ b/Formula/spotatui.rb
@@ -1,16 +1,16 @@
 class Spotatui < Formula
   desc "Spotify client for the terminal (Rust TUI, native streaming)"
   homepage "https://github.com/LargeModGames/spotatui"
-  version "0.39.1"
+  version "0.40.1"
 
   on_arm do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-aarch64.tar.gz"
-    sha256 "c95651b45b85eb43800d63d63d1b5595e4caf55a683194d0a02ed41f29970956"
+    sha256 "ac51675295ce4f24613cb182a1a9bbfd31cfaa644b0bb63f0829d93e0686b751"
   end
 
   on_intel do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-x86_64.tar.gz"
-    sha256 "874e4c96997b619beaef67abc29b82f6aba8e703bc4ebd7c65796d788b5d00b1"
+    sha256 "b338dddd00a3ae4b466e3d88884363d29de486b272d3d27aa75f4d151404aeca"
   end
 
   def install


### PR DESCRIPTION
Automated update of spotatui to version 0.40.1

- Updated version to 0.40.1
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md