### PR TITLE
Update spotatui to version 0.40.2

### DIFF
--- a/Formula/spotatui.rb
+++ b/Formula/spotatui.rb
@@ -1,16 +1,16 @@
 class Spotatui < Formula
   desc "Spotify client for the terminal (Rust TUI, native streaming)"
   homepage "https://github.com/LargeModGames/spotatui"
-  version "0.40.1"
+  version "0.40.2"
 
   on_arm do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-aarch64.tar.gz"
-    sha256 "ac51675295ce4f24613cb182a1a9bbfd31cfaa644b0bb63f0829d93e0686b751"
+    sha256 "8c1483f42141022384efdbf9769ffa67dea0c2324cef56a01c5a3cbb5806e7ba"
   end
 
   on_intel do
     url "https://github.com/LargeModGames/spotatui/releases/download/v#{version}/spotatui-macos-x86_64.tar.gz"
-    sha256 "b338dddd00a3ae4b466e3d88884363d29de486b272d3d27aa75f4d151404aeca"
+    sha256 "b62a2dede6264e6b0da592093543adef380d56f073ecb5e9d7711d5b8204f371"
   end
 
   def install


### PR DESCRIPTION
Automated update of spotatui to version 0.40.2

- Updated version to 0.40.2
- Updated SHA256 checksums for both ARM and x86_64 builds
- Updated version in README.md