### PR TITLE
Update atoll to version 2.3.2

### DIFF
--- a/Casks/atoll.rb
+++ b/Casks/atoll.rb
@@ -1,5 +1,5 @@
 cask "atoll" do
-  version "2.2.0"
+  version "2.3.2"
   sha256 ""
 
   url "https://github.com/Ebullioscopic/Atoll/releases/download/v#{version}/Atoll.#{version}.dmg",

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ brew install --cask timescam/tap/{cask}
 
 | Formula        | Version          | Description                                                                                                                                       |
 | -------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `atoll`        | `2.2.0`          | Dynamic Island utility<br />https://github.com/Ebullioscopic/Atoll                                                                                |
+| `atoll`        | `2.3.2`          | Dynamic Island utility<br />https://github.com/Ebullioscopic/Atoll                                                                                |
 | `pay-respects` | `nightly`        | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
 | `localsend-go` | `1.2.7`          | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
 | `imFile` | `2.1.0` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |


### PR DESCRIPTION
Automated update of atoll to version 2.3.2

- Updated version to 2.3.2
- Updated SHA256 checksum to b2b81d6eebb719cc50db04694d25101f85a201bac477418001348c23cecce8b8
- Updated download URL to https://github.com/Ebullioscopic/Atoll/releases/download/v2.3.2/Atoll-2.3.2.dmg
- Updated version in README.md