### PR TITLE
Update motrix-next to version 3.9.7

### DIFF
--- a/Casks/motrix-next.rb
+++ b/Casks/motrix-next.rb
@@ -1,14 +1,14 @@
 cask "motrix-next" do
-  version "3.9.6"
+  version "3.9.7"
 
   on_arm do
-    sha256 "9442e87af4211012a10a0a08d29c0fcff4caa5e75cc864444a74398fb26fac2e"
+    sha256 "dbbed535789c321a471732a5b010a1cfc55040a9e3f61a45c4723f732e4f2105"
 
     url "https://github.com/AnInsomniacy/motrix-next/releases/download/v#{version}/MotrixNext_#{version}_aarch64.dmg",
         verified: "github.com/AnInsomniacy/motrix-next/"
   end
   on_intel do
-    sha256 "ac728c2b7eead3e906d667674c86a834e29eaee6da86213f033258ec86ae51c8"
+    sha256 "3129c8bea563259d1385c9d213955ea71fa64897bd0fd1938d96cef4ad3bd088"
 
     url "https://github.com/AnInsomniacy/motrix-next/releases/download/v#{version}/MotrixNext_#{version}_x64.dmg",
         verified: "github.com/AnInsomniacy/motrix-next/"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ brew install --cask timescam/tap/{cask}
 | `localsend-go` | `1.2.7`          | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
 | `imFile` | `2.2.1` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
 | `koharu`       | `0.61.2`         | ML-powered manga translator.<br />https://github.com/mayocream/koharu                                                                             |
-| `motrix-next`  | `3.9.6`          | Modern Tauri-based download manager for macOS.<br />https://github.com/AnInsomniacy/motrix-next                                                   |
+| `motrix-next`  | `3.9.7`          | Modern Tauri-based download manager for macOS.<br />https://github.com/AnInsomniacy/motrix-next                                                   |
 | `pokeget`      | `1.6.7`          | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |
 | `zagi`         | `0.2.0`          | A better git for z.<br />https://github.com/mattzcarey/zagi                                                                                       |
 | `gopeed-web`   | `1.9.3`          | A modern download manager that supports all platforms. Built with Golang and Flutter.<br />https://github.com/GopeedLab/gopeed                    |


### PR DESCRIPTION
Automated update of motrix-next to version 3.9.7

- Updated version to 3.9.7
- Updated SHA256 checksums for both ARM and Intel builds
- Validated download assets at https://github.com/AnInsomniacy/motrix-next/releases/download/v3.9.7/MotrixNext_3.9.7_aarch64.dmg and https://github.com/AnInsomniacy/motrix-next/releases/download/v3.9.7/MotrixNext_3.9.7_x64.dmg
- Updated version in README.md