### PR TITLE
Update imFile to version 2.3.1

### DIFF
--- a/Casks/imfile.rb
+++ b/Casks/imfile.rb
@@ -1,7 +1,7 @@
 cask "imfile" do
   arch arm: "-arm64"
 
-  version "2.2.1"
+  version "2.3.1"
   sha256 arm:   "2db3324abda9aa072dab0eb6d38cf21329ad16de6b203feca74d42f5b398ee32",
          intel: "aa46960c8766a14cfc8c55571dcd407d0349af8de7f0f281ff6a15d4ac5bf7f0"
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ brew install --cask timescam/tap/{cask}
 | `atoll`        | `2.3.3`          | Dynamic Island utility<br />https://github.com/Ebullioscopic/Atoll                                                                                |
 | `pay-respects` | `nightly`        | Command suggestions, command-not-found and thefuck replacement written in Rust<br />https://codeberg.org/iff/pay-respects                         |
 | `localsend-go` | `1.2.7`          | CLI for localsend implemented in Go<br />https://github.com/meowrain/localsend-go                                                                 |
-| `imFile` | `2.2.1` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
+| `imFile` | `2.3.1` | A full-featured download manager.<br />https://github.com/imfile-io/imfile-desktop                                                                |
 | `koharu`       | `0.61.2`         | ML-powered manga translator.<br />https://github.com/mayocream/koharu                                                                             |
 | `motrix-next`  | `3.9.7`          | Modern Tauri-based download manager for macOS.<br />https://github.com/AnInsomniacy/motrix-next                                                   |
 | `pokeget`      | `1.6.7`          | A better rust version of pokeget.<br />https://github.com/talwat/pokeget-rs                                                                       |


### PR DESCRIPTION
Automated update of imFile to version 2.3.1

- Updated version to 2.3.1
- Updated SHA256 checksums for both ARM and Intel builds
- Updated download URLs to https://github.com/imfile-io/imfile-desktop/releases/download/v2.3.1/imFile-2.3.1-arm64.dmg and https://github.com/imfile-io/imfile-desktop/releases/download/v2.3.1/imFile-2.3.1.dmg
- Updated version in README.md